### PR TITLE
Replace `openpose` with `mediapipe` for pose estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## Technology Stack
 - **Python**: Core language used for scripting and processing.
 - **OpenCV**: For video processing, frame extraction, and human motion detection.
-- **OpenPose**: A machine learning framework used for pose estimation and detecting human body joints.
+- **Mediapipe**: A machine learning framework used for pose estimation and detecting human body joints.
 - **NumPy**: For handling mathematical computations related to geometry.
 - **Matplotlib**: Used to visualize the detected movements and their corresponding Labanotation.
 - **LabanWriter Integration**: The generated Labanotation is compatible with LabanWriter for further editing.
@@ -83,7 +83,7 @@ python bewegungsschrift.py --input videos/dance.mp4 --output notations/dance_not
 ## Configuration
 You can modify the settings of the tool by editing the configuration file `config.yaml`. Key configuration options include:
 - **Frame Rate**: Set the rate at which frames are sampled for analysis.
-- **Pose Estimation Model**: Choose between different pose estimation models (e.g., OpenPose, BlazePose).
+- **Pose Estimation Model**: Choose between different pose estimation models (e.g., Mediapipe, BlazePose).
 - **Output Format**: Specify the format for Labanotation output (e.g., JSON, XML).
 
 ## Examples

--- a/bewegungsschrift.py
+++ b/bewegungsschrift.py
@@ -1,7 +1,7 @@
 import argparse
 import cv2
 import numpy as np
-import openpose
+import mediapipe as mp
 import yaml
 
 def main():
@@ -46,10 +46,14 @@ def select_human_in_video(frame):
     return frame
 
 def perform_pose_estimation(frames):
+    mp_pose = mp.solutions.pose
     pose_estimations = []
-    for frame in frames:
-        pose = openpose.detect_pose(frame)
-        pose_estimations.append(pose)
+
+    with mp_pose.Pose(static_image_mode=True) as pose:
+        for frame in frames:
+            results = pose.process(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+            if results.pose_landmarks:
+                pose_estimations.append(results.pose_landmarks)
     return pose_estimations
 
 def generate_labanotation(pose_estimations):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opencv-python
 numpy
 matplotlib
-openpose
+mediapipe
 pyyaml


### PR DESCRIPTION
* **bewegungsschrift.py**
  - Import `mediapipe` instead of `openpose`
  - Update `perform_pose_estimation` function to use `mediapipe` for pose estimation

* **README.md**
  - Update technology stack section to replace `openpose` with `mediapipe`
  - Update configuration section to reflect the change in pose estimation model

* **requirements.txt**
  - Replace `openpose` dependency with `mediapipe`