### PR TITLE
Add --webcam-cube argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ After installing the necessary dependencies, you can start using **Bewegungsschr
 2. **Optional Parameters**:
     - `--select-human`: Enable human selection by drawing a border around the human in the video.
     - `--webcam-test`: Launch test from webcam.
+    - `--webcam-cube`: Launch cube test from webcam.
 
 ### Example
 To analyze a video of a dance routine and generate the corresponding Labanotation:
@@ -83,6 +84,11 @@ python bewegungsschrift.py --input videos/dance.mp4 --output notations/dance_not
 To launch a webcam test:
 ```sh
 python bewegungsschrift.py --webcam-test
+```
+
+To launch a cube test from webcam:
+```sh
+python bewegungsschrift.py --webcam-cube
 ```
 
 ## Configuration

--- a/bewegungsschrift.py
+++ b/bewegungsschrift.py
@@ -2,6 +2,7 @@ import argparse
 import yaml
 from microservices import video_input, pose_estimation, human_selection, labanotation_generation
 from microservices.pose_estimation.perform_pose_estimation import launch_webcam_test
+from microservices.pose_estimation.launch_webcam_cube_test import launch_webcam_cube_test
 
 def main():
     parser = argparse.ArgumentParser(description="Labanotation Generator from Video")
@@ -9,10 +10,15 @@ def main():
     parser.add_argument("--output", type=str, help="Path to save the generated Labanotation")
     parser.add_argument("--select-human", action="store_true", help="Enable human selection by drawing a border")
     parser.add_argument("--webcam-test", action="store_true", help="Launch test from webcam")
+    parser.add_argument("--webcam-cube", action="store_true", help="Launch cube test from webcam")
     args = parser.parse_args()
 
     if args.webcam_test:
         launch_webcam_test()
+        return
+
+    if args.webcam_cube:
+        launch_webcam_cube_test()
         return
 
     video_path = args.input

--- a/microservices/pose_estimation/launch_webcam_cube_test.py
+++ b/microservices/pose_estimation/launch_webcam_cube_test.py
@@ -1,0 +1,50 @@
+import cv2
+import mediapipe as mp
+
+def launch_webcam_cube_test():
+    mp_drawing = mp.solutions.drawing_utils
+    mp_holistic = mp.solutions.holistic
+    mp_face_mesh = mp.solutions.face_mesh
+
+    cap = cv2.VideoCapture(0)
+    with mp_holistic.Holistic(static_image_mode=False) as holistic:
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            # Convert the BGR image to RGB for processing
+            results = holistic.process(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+
+            # Draw pose landmarks
+            if results.pose_landmarks:
+                mp_drawing.draw_landmarks(frame, results.pose_landmarks, mp_holistic.POSE_CONNECTIONS)
+
+            # Draw left hand landmarks
+            if results.left_hand_landmarks:
+                mp_drawing.draw_landmarks(frame, results.left_hand_landmarks, mp_holistic.HAND_CONNECTIONS)
+
+            # Draw right hand landmarks
+            if results.right_hand_landmarks:
+                mp_drawing.draw_landmarks(frame, results.right_hand_landmarks, mp_holistic.HAND_CONNECTIONS)
+
+            # Draw face landmarks using FACEMESH_CONTOURS or FACEMESH_TESSELATION
+            if results.face_landmarks:
+                mp_drawing.draw_landmarks(frame, results.face_landmarks, mp_face_mesh.FACEMESH_CONTOURS)
+
+            # Draw a cube around the detected pose
+            if results.pose_landmarks:
+                for landmark in results.pose_landmarks.landmark:
+                    x = int(landmark.x * frame.shape[1])
+                    y = int(landmark.y * frame.shape[0])
+                    cv2.rectangle(frame, (x - 10, y - 10), (x + 10, y + 10), (0, 255, 0), 2)
+
+            # Show the frame
+            cv2.imshow('Webcam Cube Test', frame)
+
+            # Exit if 'Esc' key is pressed
+            if cv2.waitKey(5) & 0xFF == 27:
+                break
+
+    cap.release()
+    cv2.destroyAllWindows()

--- a/microservices/pose_estimation/perform_pose_estimation.py
+++ b/microservices/pose_estimation/perform_pose_estimation.py
@@ -58,3 +58,50 @@ def launch_webcam_test():
     cap.release()
     cv2.destroyAllWindows()
 
+def launch_webcam_cube_test():
+    mp_drawing = mp.solutions.drawing_utils
+    mp_holistic = mp.solutions.holistic
+    mp_face_mesh = mp.solutions.face_mesh
+
+    cap = cv2.VideoCapture(0)
+    with mp_holistic.Holistic(static_image_mode=False) as holistic:
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            # Convert the BGR image to RGB for processing
+            results = holistic.process(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+
+            # Draw pose landmarks
+            if results.pose_landmarks:
+                mp_drawing.draw_landmarks(frame, results.pose_landmarks, mp_holistic.POSE_CONNECTIONS)
+
+            # Draw left hand landmarks
+            if results.left_hand_landmarks:
+                mp_drawing.draw_landmarks(frame, results.left_hand_landmarks, mp_holistic.HAND_CONNECTIONS)
+
+            # Draw right hand landmarks
+            if results.right_hand_landmarks:
+                mp_drawing.draw_landmarks(frame, results.right_hand_landmarks, mp_holistic.HAND_CONNECTIONS)
+
+            # Draw face landmarks using FACEMESH_CONTOURS or FACEMESH_TESSELATION
+            if results.face_landmarks:
+                mp_drawing.draw_landmarks(frame, results.face_landmarks, mp_face_mesh.FACEMESH_CONTOURS)
+
+            # Draw a cube around the detected pose
+            if results.pose_landmarks:
+                for landmark in results.pose_landmarks.landmark:
+                    x = int(landmark.x * frame.shape[1])
+                    y = int(landmark.y * frame.shape[0])
+                    cv2.rectangle(frame, (x - 10, y - 10), (x + 10, y + 10), (0, 255, 0), 2)
+
+            # Show the frame
+            cv2.imshow('Webcam Cube Test', frame)
+
+            # Exit if 'Esc' key is pressed
+            if cv2.waitKey(5) & 0xFF == 27:
+                break
+
+    cap.release()
+    cv2.destroyAllWindows()

--- a/tests/test_bewegungsschrift.py
+++ b/tests/test_bewegungsschrift.py
@@ -12,6 +12,13 @@ class TestBewegungsschrift(unittest.TestCase):
             mock_launch_webcam_test.assert_called_once()
 
     @patch('bewegungsschrift.argparse.ArgumentParser.parse_args')
+    def test_main_with_webcam_cube(self, mock_parse_args):
+        mock_parse_args.return_value = MagicMock(webcam_cube=True, input=None, output=None, select_human=False)
+        with patch('bewegungsschrift.pose_estimation.launch_webcam_cube_test') as mock_launch_webcam_cube_test:
+            bewegungsschrift.main()
+            mock_launch_webcam_cube_test.assert_called_once()
+
+    @patch('bewegungsschrift.argparse.ArgumentParser.parse_args')
     def test_main_with_video_input(self, mock_parse_args):
         mock_parse_args.return_value = MagicMock(webcam_test=False, input='input.mp4', output='output.yaml', select_human=False)
         with patch('bewegungsschrift.video_input.extract_frames', return_value=['frame1', 'frame2']) as mock_extract_frames, \


### PR DESCRIPTION
Add `--webcam-cube` argument to run the webcam test inside a cube.

* **bewegungsschrift.py**
  - Add `--webcam-cube` argument to `argparse.ArgumentParser`.
  - Modify `main` function to handle `--webcam-cube` argument.
  - Call `launch_webcam_cube_test` function when `--webcam-cube` is used.

* **microservices/pose_estimation/perform_pose_estimation.py**
  - Add `launch_webcam_cube_test` function to run the webcam test inside the cube.

* **microservices/pose_estimation/launch_webcam_cube_test.py**
  - Add new file to contain the `launch_webcam_cube_test` function.
  - Implement cube functionality in the `launch_webcam_cube_test` function.

* **README.md**
  - Update usage instructions to include the `--webcam-cube` argument.
  - Add example command for using the `--webcam-cube` argument.

* **tests/test_bewegungsschrift.py**
  - Add test case to verify the `--webcam-cube` argument functionality.
  - Mock `launch_webcam_cube_test` function in the test case.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/LabanCompiler?shareId=68017b6e-eee5-4d7e-9a24-09729e1711b1).