### PR TITLE
Add 3D cube around human

### DIFF
--- a/bewegungsschrift.py
+++ b/bewegungsschrift.py
@@ -34,5 +34,22 @@ def main():
     labanotation = labanotation_generation.generate_labanotation(pose_estimations)
     labanotation_generation.save_labanotation(labanotation, output_path)
 
+    # Draw a 3D cube around the human
+    for frame in frames:
+        for pose in pose_estimations:
+            for landmark in pose.landmark:
+                x = int(landmark.x * frame.shape[1])
+                y = int(landmark.y * frame.shape[0])
+                cv2.rectangle(frame, (x - 10, y - 10), (x + 10, y + 10), (0, 255, 0), 2)
+
+    # Log the position of the human in the 3D cube
+    for pose in pose_estimations:
+        human_position = {
+            'x': pose.landmark[0].x,
+            'y': pose.landmark[0].y,
+            'z': pose.landmark[0].z
+        }
+        print(f"Human position in 3D cube: {human_position}")
+
 if __name__ == "__main__":
     main()

--- a/microservices/pose_estimation/launch_webcam_cube_test.py
+++ b/microservices/pose_estimation/launch_webcam_cube_test.py
@@ -39,6 +39,14 @@ def launch_webcam_cube_test():
                     y = int(landmark.y * frame.shape[0])
                     cv2.rectangle(frame, (x - 10, y - 10), (x + 10, y + 10), (0, 255, 0), 2)
 
+                # Log the position of the human in the 3D cube
+                human_position = {
+                    'x': results.pose_landmarks.landmark[0].x,
+                    'y': results.pose_landmarks.landmark[0].y,
+                    'z': results.pose_landmarks.landmark[0].z
+                }
+                print(f"Human position in 3D cube: {human_position}")
+
             # Show the frame
             cv2.imshow('Webcam Cube Test', frame)
 

--- a/microservices/pose_estimation/receive_frames_from_video_input.py
+++ b/microservices/pose_estimation/receive_frames_from_video_input.py
@@ -15,4 +15,11 @@ def log_body_part_positions(pose_estimations):
         for pose in pose_estimations:
             for landmark in pose.landmark:
                 logger.info(f"Body part: {landmark.name}, Position: x={landmark.x}, y={landmark.y}, z={landmark.z}")
+            # Log the position of the human in the 3D cube
+            human_position = {
+                'x': pose.landmark[0].x,
+                'y': pose.landmark[0].y,
+                'z': pose.landmark[0].z
+            }
+            logger.info(f"Human position in 3D cube: {human_position}")
         time.sleep(1)


### PR DESCRIPTION
Add functionality to draw a 3D cube around the detected human pose and log the position of the human in the 3D cube.

* **`microservices/pose_estimation/launch_webcam_cube_test.py`**
  - Add code to log the position of the human in the 3D cube.

* **`microservices/pose_estimation/receive_frames_from_video_input.py`**
  - Add code to log the position of the human in the 3D cube.

* **`bewegungsschrift.py`**
  - Add code to draw a 3D cube around the human.
  - Add code to log the position of the human in the 3D cube.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/LabanCompiler?shareId=8a4709f2-01f3-4f7c-8c66-005736e2327b).